### PR TITLE
Switch to public RingBuffer.ptr attribute

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,9 @@ API Documentation
    :members:
    :undoc-members:
 
+.. autoclass:: rtmixer.RingBuffer
+   :inherited-members:
+
 .. only:: html
 
    Index

--- a/examples/delay.py
+++ b/examples/delay.py
@@ -10,7 +10,7 @@ latency = 'low'
 samplerate = 48000
 safety = 0.1  # Shouldn't be less than the duration of an audio block
 
-qsize = 2**math.ceil(math.log2((delay + safety) * samplerate))
+rb_size = 2**math.ceil(math.log2((delay + safety) * samplerate))
 
 stream = rtmixer.MixerAndRecorder(
     channels=channels, blocksize=blocksize, samplerate=samplerate,
@@ -18,10 +18,10 @@ stream = rtmixer.MixerAndRecorder(
 with stream:
     samplesize = 4
     assert {samplesize} == set(stream.samplesize)
-    q = rtmixer.RingBuffer(samplesize * channels, qsize)
+    rb = rtmixer.RingBuffer(samplesize * channels, rb_size)
     start = stream.time + safety
-    stream.record_ringbuffer(q, start=start, allow_belated=False)
-    stream.play_ringbuffer(q, start=start + delay, allow_belated=False)
+    stream.record_ringbuffer(rb, start=start, allow_belated=False)
+    stream.play_ringbuffer(rb, start=start + delay, allow_belated=False)
     # TODO: check if start was successful
     print('#' * 80)
     print('press Return to quit')

--- a/examples/play_file.py
+++ b/examples/play_file.py
@@ -18,23 +18,23 @@ with sf.SoundFile(filename) as f:
                        blocksize=playback_blocksize,
                        samplerate=f.samplerate, latency=latency) as m:
         elementsize = f.channels * m.samplesize
-        q = rtmixer.RingBuffer(elementsize, reading_blocksize * reading_qsize)
+        rb = rtmixer.RingBuffer(elementsize, reading_blocksize * reading_qsize)
         # Pre-fill ringbuffer:
-        _, buf, _ = q.get_write_buffers(reading_blocksize * reading_qsize)
+        _, buf, _ = rb.get_write_buffers(reading_blocksize * reading_qsize)
         written = f.buffer_read_into(buf, dtype='float32')
-        q.advance_write_index(written)
-        action = m.play_ringbuffer(q)
+        rb.advance_write_index(written)
+        action = m.play_ringbuffer(rb)
         while True:
-            while q.write_available < reading_blocksize:
+            while rb.write_available < reading_blocksize:
                 if action not in m.actions:
                     break
                 sd.sleep(int(1000 * reading_blocksize / f.samplerate))
             if action not in m.actions:
                 break
-            size, buf1, buf2 = q.get_write_buffers(reading_blocksize)
+            size, buf1, buf2 = rb.get_write_buffers(reading_blocksize)
             assert not buf2
             written = f.buffer_read_into(buf1, dtype='float32')
-            q.advance_write_index(written)
+            rb.advance_write_index(written)
             if written < size:
                 break
         m.wait(action)

--- a/examples/plot_input.py
+++ b/examples/plot_input.py
@@ -19,16 +19,16 @@ latency = 'low'
 device = None
 samplerate = None
 downsample = 10  # Plot every ...th frame
-qsize = 8  # Power of 2
+rb_size = 8  # Power of 2
 channels = 2
 
 
 def update_plot(frame):
     global plotdata
-    while q.read_available >= stepsize:
+    while rb.read_available >= stepsize:
         # The ring buffer's size is a multiple of stepsize, therefore we know
         # that the data is contiguous in memory (= the 2nd buffer is empty):
-        read, buf1, buf2 = q.get_read_buffers(stepsize)
+        read, buf1, buf2 = rb.get_read_buffers(stepsize)
         assert read == stepsize
         assert not buf2
         buffer = np.frombuffer(buf1, dtype='float32')
@@ -39,7 +39,7 @@ def update_plot(frame):
         shift = len(buffer)
         plotdata = np.roll(plotdata, -shift, axis=0)
         plotdata[-shift:, :] = buffer
-        q.advance_read_index(stepsize)
+        rb.advance_read_index(stepsize)
     for column, line in enumerate(lines):
         line.set_ydata(plotdata[:, column])
     return lines
@@ -73,7 +73,7 @@ stream = rtmixer.Recorder(
 ani = FuncAnimation(fig, update_plot, interval=interval, blit=True)
 with stream:
     elementsize = channels * stream.samplesize
-    q = rtmixer.RingBuffer(elementsize, stepsize * qsize)
-    action = stream.record_ringbuffer(q)
+    rb = rtmixer.RingBuffer(elementsize, stepsize * rb_size)
+    action = stream.record_ringbuffer(rb)
     plt.show()
 print('Input overflows:', action.stats.input_overflows)

--- a/src/rtmixer.py
+++ b/src/rtmixer.py
@@ -20,8 +20,8 @@ class _Base(_sd._StreamBase):
             input_channels=0,
             output_channels=0,
             samplerate=0,
-            action_q=self._action_q._ptr,
-            result_q=self._result_q._ptr,
+            action_q=self._action_q.ptr,
+            result_q=self._result_q.ptr,
             actions=_ffi.NULL,
         ))
         _sd._StreamBase.__init__(
@@ -144,15 +144,15 @@ class Mixer(_Base):
         """
         _, samplesize = _sd._split(self.samplesize)
         if channels is None:
-            channels = ringbuffer.elementsize // samplesize
+            channels = ringbuffer.ptr.elementSizeBytes // samplesize
         channels, mapping = self._check_channels(channels, 'output')
-        if ringbuffer.elementsize != samplesize * channels:
+        if ringbuffer.ptr.elementSizeBytes != samplesize * channels:
             raise ValueError('Incompatible elementsize')
         action = _ffi.new('struct action*', dict(
             type=_lib.PLAY_RINGBUFFER,
             allow_belated=allow_belated,
             requested_time=start,
-            ringbuffer=ringbuffer._ptr,
+            ringbuffer=ringbuffer.ptr,
             total_frames=_lib.ULONG_MAX,
             channels=channels,
             mapping=mapping,
@@ -205,15 +205,15 @@ class Recorder(_Base):
         """
         samplesize, _ = _sd._split(self.samplesize)
         if channels is None:
-            channels = ringbuffer.elementsize // samplesize
+            channels = ringbuffer.ptr.elementSizeBytes // samplesize
         channels, mapping = self._check_channels(channels, 'input')
-        if ringbuffer.elementsize != samplesize * channels:
+        if ringbuffer.ptr.elementSizeBytes != samplesize * channels:
             raise ValueError('Incompatible elementsize')
         action = _ffi.new('struct action*', dict(
             type=_lib.RECORD_RINGBUFFER,
             allow_belated=allow_belated,
             requested_time=start,
-            ringbuffer=ringbuffer._ptr,
+            ringbuffer=ringbuffer.ptr,
             total_frames=_lib.ULONG_MAX,
             channels=channels,
             mapping=mapping,


### PR DESCRIPTION
This will be needed if https://github.com/mgeier/python-pa-ringbuffer/pull/6 gets merged.