### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     package_dir={'': 'src'},
     py_modules=['rtmixer'],
     cffi_modules=['rtmixer_build.py:ffibuilder'],
+    python_requires='>=2.6',
     setup_requires=[
         'CFFI>=1.4.0',
         'pa_ringbuffer',  # for cdef()
@@ -29,7 +30,7 @@ setup(
     long_description=open('README.rst').read(),
     license='MIT',
     keywords='sound audio PortAudio realtime low-latency'.split(),
-    url='http://python-rtmixer.readthedocs.io/',
+    url='https://python-rtmixer.readthedocs.io/',
     platforms='any',
     classifiers=[
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Currently, that's not really doing anything, but we need this if we want to drop Python 2 at some point, in order to allow Python 2 users to still be able to install the last supported release.