### PR TITLE
Use `actual_time` to encode `allow_belated` argument

### DIFF
--- a/examples/bleeperoo.py
+++ b/examples/bleeperoo.py
@@ -90,7 +90,6 @@ min_delay = np.inf
 max_delay = -np.inf
 for action in actionlist:
     assert action.type == rtmixer.PLAY_BUFFER
-    # NB: action.allow_belated might have been invalidated
     assert action.requested_time != 0
     if not action.actual_time:
         belated += 1

--- a/src/rtmixer.c
+++ b/src/rtmixer.c
@@ -160,7 +160,7 @@ int callback(const void* input, void* output, frame_t frameCount
 
           // Due to inaccuracies in timeInfo, "diff" might have a small negative
           // value in a future block.  We don't count this as "belated" though:
-          action->allow_belated = true;
+          action->actual_time = -1.0;
           actionaddr = &(action->next);
           continue;
         }
@@ -170,9 +170,9 @@ int callback(const void* input, void* output, frame_t frameCount
       else
       {
         // We are too late!
-        if (!action->allow_belated)
+        if (action->actual_time == 0.0)
         {
-          action->actual_time = 0.0;  // a.k.a. "false"
+          // allow_belated == False
           remove_action(actionaddr, state);
           continue;
         }
@@ -213,8 +213,10 @@ int callback(const void* input, void* output, frame_t frameCount
             }
             else
             {
-              if (!delinquent->allow_belated)
+              if (delinquent->actual_time == 0.0)
               {
+                // allow_belated == False
+
                 // TODO: save some status information?
                 break;  // The action will not be started, no need to cancel it
               }

--- a/src/rtmixer.h
+++ b/src/rtmixer.h
@@ -34,9 +34,8 @@ struct stats
 struct action
 {
   const enum actiontype type;
-  bool allow_belated;  // NB: Might be invalidated in the callback function!
   const PaTime requested_time;
-  PaTime actual_time;
+  PaTime actual_time;  // Set != 0.0 to allow belated actions
   struct action* next;  // Used to create singly linked list of actions
   union {
     float* const buffer;

--- a/src/rtmixer.h
+++ b/src/rtmixer.h
@@ -6,9 +6,6 @@ typedef unsigned long PaStreamCallbackFlags;
 
 typedef unsigned long frame_t;
 struct PaUtilRingBuffer;
-typedef _Bool bool;
-#define true 1
-#define false 0
 
 enum actiontype
 {

--- a/src/rtmixer.py
+++ b/src/rtmixer.py
@@ -72,7 +72,7 @@ class _Base(_sd._StreamBase):
         """
         cancel_action = _ffi.new('struct action*', dict(
             type=CANCEL,
-            allow_belated=allow_belated,
+            actual_time=-1.0 if allow_belated else 0.0,
             requested_time=time,
             action=action,
         ))
@@ -88,7 +88,7 @@ class _Base(_sd._StreamBase):
         """
         action = _ffi.new('struct action*', dict(
             type=FETCH_AND_RESET_STATS,
-            allow_belated=allow_belated,
+            actual_time=-1.0 if allow_belated else 0.0,
             requested_time=time,
         ))
         self._enqueue(action)
@@ -173,7 +173,7 @@ class Mixer(_Base):
         _, samplesize = _sd._split(self.samplesize)
         action = _ffi.new('struct action*', dict(
             type=PLAY_BUFFER,
-            allow_belated=allow_belated,
+            actual_time=-1.0 if allow_belated else 0.0,
             requested_time=start,
             buffer=_ffi.cast('float*', buffer),
             total_frames=len(buffer) // channels // samplesize,
@@ -199,7 +199,7 @@ class Mixer(_Base):
             raise ValueError('Incompatible elementsize')
         action = _ffi.new('struct action*', dict(
             type=PLAY_RINGBUFFER,
-            allow_belated=allow_belated,
+            actual_time=-1.0 if allow_belated else 0.0,
             requested_time=start,
             ringbuffer=ringbuffer._ptr,
             total_frames=ULONG_MAX,
@@ -238,7 +238,7 @@ class Recorder(_Base):
         samplesize, _ = _sd._split(self.samplesize)
         action = _ffi.new('struct action*', dict(
             type=RECORD_BUFFER,
-            allow_belated=allow_belated,
+            actual_time=-1.0 if allow_belated else 0.0,
             requested_time=start,
             buffer=_ffi.cast('float*', buffer),
             total_frames=len(buffer) // channels // samplesize,
@@ -264,7 +264,7 @@ class Recorder(_Base):
             raise ValueError('Incompatible elementsize')
         action = _ffi.new('struct action*', dict(
             type=RECORD_RINGBUFFER,
-            allow_belated=allow_belated,
+            actual_time=-1.0 if allow_belated else 0.0,
             requested_time=start,
             ringbuffer=ringbuffer._ptr,
             total_frames=ULONG_MAX,


### PR DESCRIPTION
This is probably a bad idea ...

But it avoids the awkwardness of the original `allow_belated` value potentially being invalidated.

And we don't need to define the `bool` type (see also #2)!