### PR TITLE
ENH: Switch to abi3 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -52,10 +52,8 @@ jobs:
         if: runner.os == 'Linux' && matrix.arch == 'aarch64'
       - uses: pypa/cibuildwheel@v2.19.1
         env:
-          CIBW_BUILDING: "true"
-          CIBW_ARCHS: ${{ matrix.arch }}  # simplest for now
+          CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_BUILD: "${{ matrix.python }}-*"
-          CIBW_SKIP: "{c,p}p3{6,7}-*"
           CIBW_TEST_COMMAND: "python -c \"import rtmixer; print(rtmixer.__version__)\""
           # No portaudio on these platforms:
           CIBW_TEST_SKIP: "*_i686 *-musllinux_* *_aarch64"
@@ -65,6 +63,8 @@ jobs:
           CIBW_BEFORE_TEST_LINUX: "bash {project}/tools/cibw_before_test_linux.sh"
           # Use abi3audit to catch issues with Limited API wheels
           CIBW_REPAIR_WHEEL_COMMAND: "bash ./tools/cibw_repair_wheel_command.sh {dest_dir} {wheel} {delocate_archs}"
+          CIBW_ENVIRONMENT_PASS_LINUX: "RUNNER_OS"
+          CIBW_PROJECT_REQUIRES_PYTHON: "3.8"
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch}}-${{ strategy.job-index }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -64,7 +64,7 @@ jobs:
           # Use abi3audit to catch issues with Limited API wheels
           CIBW_REPAIR_WHEEL_COMMAND: "bash ./tools/cibw_repair_wheel_command.sh {dest_dir} {wheel} {delocate_archs}"
           CIBW_ENVIRONMENT_PASS_LINUX: "RUNNER_OS"
-          CIBW_PROJECT_REQUIRES_PYTHON: "3.8"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch}}-${{ strategy.job-index }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: ${{ matrix.os }} ${{ matrix.arch }} py${{ matrix.python}} wheels
+    name: ${{ matrix.os }} ${{ matrix.arch }} wheels
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: ${{ matrix.os }} ${{ matrix.arch }} wheels
+    name: ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.python}} wheels
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:
@@ -22,11 +22,24 @@ jobs:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
         arch: [native]
+        python: ["{cp38,pp*}"]
+        # Split aarch64 across jobs because it uses emulation (slow)
         include:
           - os: ubuntu-latest
             arch: i686
+            python: "{cp38,pp*}"
           - os: ubuntu-latest
             arch: aarch64
+            python: "cp38"
+          - os: ubuntu-latest
+            arch: aarch64
+            python: "pp38"
+          - os: ubuntu-latest
+            arch: aarch64
+            python: "pp39"
+          - os: ubuntu-latest
+            arch: aarch64
+            python: "pp310"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,7 +54,8 @@ jobs:
         env:
           CIBW_BUILDING: "true"
           CIBW_ARCHS: ${{ matrix.arch }}  # simplest for now
-          CIBW_BUILD: "{c,p}p38-*"  # abi3 wheels against oldest supported version
+          CIBW_BUILD: "${{ matrix.python }}-*"
+          CIBW_SKIP: "{c,p}p3{6,7}-*"
           CIBW_TEST_COMMAND: "python -c \"import rtmixer; print(rtmixer.__version__)\""
           # No portaudio on these platforms:
           CIBW_TEST_SKIP: "*_i686 *-musllinux_* *_aarch64"
@@ -50,9 +64,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: "3"
           CIBW_BEFORE_TEST_LINUX: "bash {project}/tools/cibw_before_test_linux.sh"
           # Use abi3audit to catch issues with Limited API wheels
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} && pipx run abi3audit --strict --report {wheel}"
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} && pipx run abi3audit --strict --report {wheel}"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "pipx run abi3audit --strict --report {wheel}"
+          CIBW_REPAIR_WHEEL_COMMAND: "bash {project}/tools/cibw_repair_wheel_command.sh {dest_dir} {wheel} {delocate_archs}"
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch}}-${{ strategy.job-index }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,27 +22,11 @@ jobs:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
         arch: [native]
-        python: ["*"]
-        # Split aarch64 across jobs because it uses emulation (slow)
         include:
           - os: ubuntu-latest
             arch: i686
-            python: "*"
           - os: ubuntu-latest
             arch: aarch64
-            python: "38"
-          - os: ubuntu-latest
-            arch: aarch64
-            python: "39"
-          - os: ubuntu-latest
-            arch: aarch64
-            python: "310"
-          - os: ubuntu-latest
-            arch: aarch64
-            python: "311"
-          - os: ubuntu-latest
-            arch: aarch64
-            python: "312"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -57,8 +41,7 @@ jobs:
         env:
           CIBW_BUILDING: "true"
           CIBW_ARCHS: ${{ matrix.arch }}  # simplest for now
-          CIBW_BUILD: "{c,p}p${{ matrix.python }}-*"
-          CIBW_SKIP: "{c,p}p3{6,7}-*"
+          CIBW_BUILD: "{c,p}p38-*"  # abi3 wheels against oldest supported version
           CIBW_TEST_COMMAND: "python -c \"import rtmixer; print(rtmixer.__version__)\""
           # No portaudio on these platforms:
           CIBW_TEST_SKIP: "*_i686 *-musllinux_* *_aarch64"
@@ -66,6 +49,10 @@ jobs:
           # CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
           CIBW_BUILD_VERBOSITY: "3"
           CIBW_BEFORE_TEST_LINUX: "bash {project}/tools/cibw_before_test_linux.sh"
+          # Use abi3audit to catch issues with Limited API wheels
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} && pipx run abi3audit --strict --report {wheel}"
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} && pipx run abi3audit --strict --report {wheel}"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "pipx run abi3audit --strict --report {wheel}"
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch}}-${{ strategy.job-index }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -64,7 +64,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: "3"
           CIBW_BEFORE_TEST_LINUX: "bash {project}/tools/cibw_before_test_linux.sh"
           # Use abi3audit to catch issues with Limited API wheels
-          CIBW_REPAIR_WHEEL_COMMAND: "bash {project}/tools/cibw_repair_wheel_command.sh {dest_dir} {wheel} {delocate_archs}"
+          CIBW_REPAIR_WHEEL_COMMAND: "bash ./tools/cibw_repair_wheel_command.sh {dest_dir} {wheel} {delocate_archs}"
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch}}-${{ strategy.job-index }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -48,7 +48,6 @@ jobs:
           # To enable testing we'd have to bump up to the Almalinux 8-based image:
           # CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
           CIBW_BUILD_VERBOSITY: "3"
-          CIBW_BEFORE_BUILD: "pip install wheel"
           CIBW_BEFORE_TEST_LINUX: "bash {project}/tools/cibw_before_test_linux.sh"
           # Use abi3audit to catch issues with Limited API wheels
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} && pipx run abi3audit --strict --report {wheel}"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -48,6 +48,7 @@ jobs:
           # To enable testing we'd have to bump up to the Almalinux 8-based image:
           # CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
           CIBW_BUILD_VERBOSITY: "3"
+          CIBW_BEFORE_BUILD: "pip install wheel"
           CIBW_BEFORE_TEST_LINUX: "bash {project}/tools/cibw_before_test_linux.sh"
           # Use abi3audit to catch issues with Limited API wheels
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel} && pipx run abi3audit --strict --report {wheel}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/*.so
 src/*.egg-info
 __pycache__
 .eggs
+/dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,15 @@ for line in open('src/rtmixer.py'):
         break
 
 
-# Adapted from https://github.com/joerick/python-abi3-package-sample/blob/main/setup.py
+# Adapted from
+# https://github.com/joerick/python-abi3-package-sample/blob/main/setup.py
 class bdist_wheel_abi3(bdist_wheel):
     def get_tag(self):
         python, abi, plat = super().get_tag()
 
         if python.startswith("cp"):
-            # on CPython, our wheels are abi3 and compatible back to 3.2, but let's
-            # set it to our min version anyway
+            # on CPython, our wheels are abi3 and compatible back to 3.2,
+            # but let's set it to our min version anyway
             return "cp38", "abi3", plat
 
         return python, abi, plat

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup
+from setuptools import setup, Extension
+from wheel.bdist_wheel import bdist_wheel
 
 __version__ = 'unknown'
 
@@ -8,12 +9,26 @@ for line in open('src/rtmixer.py'):
         exec(line)
         break
 
+
+# Adapted from https://github.com/joerick/python-abi3-package-sample/blob/main/setup.py
+class bdist_wheel_abi3(bdist_wheel):
+    def get_tag(self):
+        python, abi, plat = super().get_tag()
+
+        if python.startswith("cp"):
+            # on CPython, our wheels are abi3 and compatible back to 3.2, but let's
+            # set it to our min version anyway
+            return "cp38", "abi3", plat
+
+        return python, abi, plat
+
+
 setup(
     name='rtmixer',
     version=__version__,
     package_dir={'': 'src'},
     py_modules=['rtmixer'],
-    cffi_modules=['rtmixer_build.py:ffibuilder'],
+    cffi_modules=['rtmixer_build.py:ffibuilder'],  # sets Py_LIMITED_API for us
     python_requires='>=3.6',
     setup_requires=[
         'CFFI>=1.4.0',
@@ -39,4 +54,5 @@ setup(
         'Programming Language :: Python :: 3',
         'Topic :: Multimedia :: Sound/Audio',
     ],
+    cmdclass={"bdist_wheel": bdist_wheel_abi3},
 )

--- a/src/rtmixer.py
+++ b/src/rtmixer.py
@@ -3,7 +3,7 @@
 https://python-rtmixer.readthedocs.io/
 
 """
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 
 import sounddevice as _sd
 from pa_ringbuffer import init as _init_ringbuffer

--- a/tools/cibw_repair_wheel_command.sh
+++ b/tools/cibw_repair_wheel_command.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -xeo pipefail
+
+DEST_DIR=$1
+WHEEL=$2
+DELOCATE_ARCHS=$3
+if [[ "$RUNNER_OS" == "Linux" ]]; then
+    auditwheel repair -w $DEST_DIR $WHEEL
+elif [[ "$RUNNER_OS" == "macOS" ]]; then
+    delocate-wheel --require-archs $DELOCATE_ARCHS -w $DEST_DIR -v $WHEEL
+fi
+
+if [[ "$(python -c 'import platform; print(platform.python_implementation())')" == "CPython" ]]; then
+    pipx run abi3audit --strict --report $WHEEL
+fi

--- a/tools/cibw_repair_wheel_command.sh
+++ b/tools/cibw_repair_wheel_command.sh
@@ -9,6 +9,8 @@ if [[ "$RUNNER_OS" == "Linux" ]]; then
     auditwheel repair -w $DEST_DIR $WHEEL
 elif [[ "$RUNNER_OS" == "macOS" ]]; then
     delocate-wheel --require-archs $DELOCATE_ARCHS -w $DEST_DIR -v $WHEEL
+else
+    cp $WHEEL $DEST_DIR
 fi
 
 if [[ "$(python -c 'import platform; print(platform.python_implementation())')" == "CPython" ]]; then


### PR DESCRIPTION
@mgeier locally this worked:
```
$ python setup.py bdist_wheel
...
$ $ ls dist/
rtmixer-0.1.5-cp38-abi3-macosx_11_0_arm64.whl
```
and then I could install it, too.