### PR TITLE
BUG: Fix download bug with image

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -54,6 +54,8 @@ jobs:
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_BUILD: "${{ matrix.python }}-*"
+          CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2014_x86_64:latest"
+          CIBW_MANYLINUX_AARCH64_IMAGE: "quay.io/pypa/manylinux2014_aarch64:latest"
           CIBW_TEST_COMMAND: "python -c \"import rtmixer; print(rtmixer.__version__)\""
           # No portaudio on these platforms:
           CIBW_TEST_SKIP: "*_i686 *-musllinux_* *_aarch64"

--- a/src/rtmixer.py
+++ b/src/rtmixer.py
@@ -3,7 +3,7 @@
 https://python-rtmixer.readthedocs.io/
 
 """
-__version__ = '0.1.6'
+__version__ = '0.1.7'
 
 import sounddevice as _sd
 from pa_ringbuffer import init as _init_ringbuffer


### PR DESCRIPTION
Not entirely sure why the PyPI upload went when one of these jobs failed

https://github.com/spatialaudio/python-rtmixer/actions/runs/9764426533/job/26952736643

I didn't think the fail-fast continue-on-error would affect the `needs` later. But in the meantime we can bump the version, make sure this is green, then merge.