### PR TITLE
remove license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     url='https://python-rtmixer.readthedocs.io/',
     platforms='any',
     classifiers=[
-        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
I'm getting build errors like

```
********************************************************************************
Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: MIT License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
********************************************************************************
```

stemming from `SetuptoolsDeprecationWarning: License classifiers are deprecated.`

Since `setup.py` already includes a `license = "MIT"` field, it should be OK to simply remove this classifier. Building rtmixer from this fork/branch made the error go away.