### PR TITLE
RTD: add now required sphinx.configuration setting

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,5 +9,7 @@ build:
 python:
   install:
     - requirements: doc/requirements.txt
+sphinx:
+  configuration: doc/conf.py
 formats:
   - pdf


### PR DESCRIPTION
This caused a build failure at RTD: https://app.readthedocs.org/projects/python-rtmixer/builds/30864889/