### PR TITLE
Fix wheel build and prefer pyproject.toml

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           platforms: all
         if: runner.os == 'Linux' && matrix.arch == 'aarch64'
-      - uses: pypa/cibuildwheel@v2.20.0
+      - uses: pypa/cibuildwheel@v3.3.0
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_BUILD: "${{ matrix.python }}-*"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -19,27 +19,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
         arch: [native]
-        python: ["{cp38,pp*}"]
+        python: ["{cp310,pp310,pp311}"]
         # Split aarch64 across jobs because it uses emulation (slow)
         include:
           - os: ubuntu-latest
             arch: i686
-            python: "{cp38,pp*}"
+            python: "{cp310,pp310,pp311}"
           - os: ubuntu-latest
             arch: aarch64
-            python: "cp38"
-          - os: ubuntu-latest
-            arch: aarch64
-            python: "pp38"
-          - os: ubuntu-latest
-            arch: aarch64
-            python: "pp39"
+            python: "cp310"
           - os: ubuntu-latest
             arch: aarch64
             python: "pp310"
+          - os: ubuntu-latest
+            arch: aarch64
+            python: "pp3{10,11}"
+          - os: ubuntu-latest
+            arch: aarch64
+            python: "pp3{10,11}"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,19 +53,6 @@ jobs:
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_BUILD: "${{ matrix.python }}-*"
-          CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2014_x86_64:latest"
-          CIBW_MANYLINUX_AARCH64_IMAGE: "quay.io/pypa/manylinux2014_aarch64:latest"
-          CIBW_TEST_COMMAND: "python -c \"import rtmixer; print(rtmixer.__version__)\""
-          # No portaudio on these platforms:
-          CIBW_TEST_SKIP: "*_i686 *-musllinux_* *_aarch64"
-          # To enable testing we'd have to bump up to the Almalinux 8-based image:
-          # CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
-          CIBW_BUILD_VERBOSITY: "3"
-          CIBW_BEFORE_TEST_LINUX: "bash {project}/tools/cibw_before_test_linux.sh"
-          # Use abi3audit to catch issues with Limited API wheels
-          CIBW_REPAIR_WHEEL_COMMAND: "bash ./tools/cibw_repair_wheel_command.sh {dest_dir} {wheel} {delocate_archs}"
-          CIBW_ENVIRONMENT_PASS_LINUX: "RUNNER_OS"
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch}}-${{ strategy.job-index }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/*.egg-info
 __pycache__
 .eggs
 /dist/
+/wheelhouse/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,51 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "pa_ringbuffer", "cffi>=1.4.0"]
 build-backend = "setuptools.build_meta"
+
+[project]
+requires-python = ">=3.10"
+name = "rtmixer"
+dynamic = ["version"]
+readme = {content-type = "text/x-rst", file = "README.rst"}
+authors = [
+  {email = "Matthias.Geier@gmail.com", name = "Matthias Geier"},
+]
+description = 'Reliable low-latency audio playback and recording'
+license = 'MIT'
+keywords = [
+    "sound", "audio", "PortAudio", "realtime", "low-latency"
+]
+dependencies = [
+    'CFFI>=1',  # for _cffi_backend
+    'pa_ringbuffer',  # for init()
+    'sounddevice>0.3.9',
+]
+classifiers =[
+    'Operating System :: OS Independent',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Topic :: Multimedia :: Sound/Audio',
+]
+
+[project.urls]
+"Bug Tracker" = "https://github.com/spatialaudio/python-rtmixer/issues"
+Documentation = "https://python-rtmixer.readthedocs.io"
+Homepage = "https://python-rtmixer.readthedocs.io"
+"Source Code" = "https://github.com/spatialaudio/python-rtmixer"
+
+[tool.cibuildwheel]
+enable = ["pypy"]
+manylinux-aarch64-image = "manylinux2014"
+manylinux-pypy_x86_64-image = "manylinux2014"
+manylinux-pypy_aarch64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux2014"
+test-command = "python -c \"import rtmixer; print(rtmixer.__version__)\""
+# No portaudio on these platforms:
+test-skip = "*_i686 *-musllinux_* *_aarch64"
+# To enable testing we'd have to bump up to the Almalinux 8-based image:
+# manylinux-aarch64-image = "manylinux_2_28"
+repair-wheel-command = "bash ./tools/cibw_repair_wheel_command.sh {dest_dir} {wheel} {delocate_archs}"
+
+[tool.cibuildwheel.linux]
+before-test = "bash {project}/tools/cibw_before_test_linux.sh"
+environment = { RUNNER_OS="Linux" }  # facilitate local testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Homepage = "https://python-rtmixer.readthedocs.io"
 "Source Code" = "https://github.com/spatialaudio/python-rtmixer"
 
 [tool.cibuildwheel]
-enable = ["pypy"]
+enable = ["pypy", "pypy-eol"]
 manylinux-aarch64-image = "manylinux2014"
 manylinux-pypy_x86_64-image = "manylinux2014"
 manylinux-pypy_aarch64-image = "manylinux2014"

--- a/setup.py
+++ b/setup.py
@@ -19,40 +19,15 @@ class bdist_wheel_abi3(bdist_wheel):
         if python.startswith("cp"):
             # on CPython, our wheels are abi3 and compatible back to 3.2,
             # but let's set it to our min version anyway
-            return "cp38", "abi3", plat
+            return "cp310", "abi3", plat
 
         return python, abi, plat
 
 
 setup(
-    name='rtmixer',
     version=__version__,
     package_dir={'': 'src'},
     py_modules=['rtmixer'],
     cffi_modules=['rtmixer_build.py:ffibuilder'],  # sets Py_LIMITED_API for us
-    python_requires='>=3.6',
-    setup_requires=[
-        'CFFI>=1.4.0',
-        'pa_ringbuffer',  # for cdef()
-    ],
-    install_requires=[
-        'CFFI>=1',  # for _cffi_backend
-        'pa_ringbuffer',  # for init()
-        'sounddevice>0.3.9',
-    ],
-    author='Matthias Geier',
-    author_email='Matthias.Geier@gmail.com',
-    description='Reliable low-latency audio playback and recording',
-    long_description=open('README.rst').read(),
-    license='MIT',
-    keywords='sound audio PortAudio realtime low-latency'.split(),
-    url='https://python-rtmixer.readthedocs.io/',
-    platforms='any',
-    classifiers=[
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Topic :: Multimedia :: Sound/Audio',
-    ],
     cmdclass={"bdist_wheel": bdist_wheel_abi3},
 )


### PR DESCRIPTION
1. Bump Python min to 3.10 (3.9 is EOL)
2. Change PyPy to be 3.10 and 3.11
3. Move `setup.py` config vars to `pyproject.toml`
4. Move `cibuildwheel` config vars to `pyproject.toml` (makes `cibuildwheel .` local testing easier which is nice! and now CI config vars that get passed only have to do with limiting the scope of that job's build)
5. Bump runners to modern `macos-*` variants
6. Bump cibuildwheel version

Let's see if it comes back green :crossed_fingers: (or more realistically, that it doesn't take 100 additional commits to get us there...)

Closes #64