### PR TITLE
Explicitly include `stdbool.h`

### DIFF
--- a/src/rtmixer.c
+++ b/src/rtmixer.c
@@ -1,6 +1,7 @@
 /* See ../rtmixer_build.py, the ring buffer declarations are included there */
 
 #include <math.h>  // for llround()
+#include <stdbool.h>
 #include <stdio.h>  // for printf()
 #include <string.h>  // for memset()
 #include <portaudio.h>


### PR DESCRIPTION
Fixes issue https://github.com/spatialaudio/python-rtmixer/issues/69.